### PR TITLE
TV complexe et MEX functions pour Matlab

### DIFF
--- a/matlab/m_regul_totvar_2d.c
+++ b/matlab/m_regul_totvar_2d.c
@@ -1,0 +1,79 @@
+/* 	
+ function m_regul_totvar_2d
+
+  [fx, gx] = m_regul_totvar_2d(x, w1, w2, eps, flags);
+                                      
+  MexFile to call from Matlab the rgl_tv2d function of the Totvar library.
+ 
+  Compilation :
+        mex m_regul_totvar_2d.c totvar.o
+  
+  Juillet 2015
+  CEA-LETI
+  Fabien Momey
+*/
+
+#include "matrix.h"
+#include "mex.h"
+#include "../totvar.h"
+
+void mexFunction( int nlhs1, mxArray *plhs[],    
+                  int nrhs, const mxArray *prhs[] )
+{ 
+    double w1, w2, eps;
+    mwSize n1, n2, nDims; 
+    const mwSize *pDims;
+    const mwSize pDims2[] = {1,1};
+	unsigned int flags; 
+	double *x;
+
+    double *fx;
+    double *gx; 
+
+    /* Control of the number of inputs and outputs */ 
+    if (nrhs > 5)
+        mexErrMsgTxt("5 input argument required."); 
+    else if (nlhs1 !=2) 
+        mexErrMsgTxt("2 output argument required.");
+    
+    /* Control of the inputs */
+	if (!mxIsNumeric(prhs[0]) || !mxIsDouble(prhs[0])) 
+        mexErrMsgTxt("The first input must be numerical double array.");
+    if (!mxIsNumeric(prhs[1]) || !mxIsScalar(prhs[1])
+        || !mxIsNumeric(prhs[2]) || !mxIsScalar(prhs[2]) 
+		|| !mxIsNumeric(prhs[3]) || !mxIsScalar(prhs[3])
+        || !mxIsNumeric(prhs[4]) || !mxIsScalar(prhs[4]) ) 
+        mexErrMsgTxt("The 4 last input must be scalar."); 
+    
+    if ( (double )(unsigned int )mxGetScalar(prhs[4]) != mxGetScalar(prhs[4]) )
+        mexErrMsgTxt("The last input flags must be an unsigned integer.");
+    
+    /* Get the inputs */
+    w1        = (double )mxGetScalar(prhs[1]);
+    w2        = (double )mxGetScalar(prhs[2]);
+    eps       = (double )mxGetScalar(prhs[3]);
+    flags     = (unsigned int )mxGetScalar(prhs[4]);
+    flags    |= RGL_INTEGRATE_GRADIENT;
+		
+    nDims = mxGetNumberOfDimensions(prhs[0]);
+    pDims = mxGetDimensions(prhs[0]);
+    x = mxGetPr(prhs[0]);	
+    
+    n1        = pDims[0];
+    n2        = pDims[1];
+
+    /* Display the inputs */
+    /* mexPrintf("n1 = %d, n2 = %d, w1 = %f, w2 = %f, eps = %f, flags = %d\n", n1, n2, w1, w2, eps, flags); */
+    
+    /* Create the output arguments */
+    /* Argument fx */
+    plhs[0] = mxCreateNumericArray(2, pDims2, mxDOUBLE_CLASS, mxREAL);
+    fx = mxGetPr(plhs[0]);
+    
+    /* Argument gx */
+    plhs[1] = mxCreateNumericArray(nDims, pDims, mxDOUBLE_CLASS, mxREAL);
+    gx = mxGetPr(plhs[1]);
+   
+    /* Call to the rgl_tv3d function */
+    *fx = rgl_tv2d(x,n1,n2,w1,w2,eps,gx,flags); 
+}

--- a/matlab/m_regul_totvar_2d.c
+++ b/matlab/m_regul_totvar_2d.c
@@ -3,10 +3,12 @@
 
   [fx, gx] = m_regul_totvar_2d(x, w1, w2, eps, flags);
                                       
-  MexFile to call from Matlab the rgl_tv2d function of the Totvar library.
+  MexFile to call from Matlab the rgl_tv2d function of the Totvar library
+  which implements Definitions for relaxed Total Variation (TV)
+  for images with complex values.
  
   Compilation :
-        mex m_regul_totvar_2d.c totvar.o
+        mex m_regul_totvar_2d.c ../totvar.o (or totvar.obj)
   
   Juillet 2015
   CEA-LETI

--- a/matlab/m_regul_totvar_2d.m
+++ b/matlab/m_regul_totvar_2d.m
@@ -3,10 +3,11 @@
 % 
 %  [fx, gx] = m_regul_totvar_2d(x, w1, w2, eps, flags);
 %                                       
-%  MexFile to call from Matlab the rgl_tv2d function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  MexFile to call from Matlab the rgl_tv2d function of the totvar library 
+%  which implements Definitions for relaxed Total Variation (TV).
 %  
 %  Compilation :
-%        mex m_regul_totvar_2d.c totvar.o
+%        mex m_regul_totvar_2d.c ../totvar.o (or totvar.obj)
 %   
 %  Juillet 2015
 %  CEA-LETI
@@ -16,9 +17,9 @@
 %  * Information about totvar library
 %  *-----------------------------------------------------------------------------
 %  *
-%  * Copyright (C) 2010-2014, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>,
-%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
-%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  * Copyright (C) 2010-2014, ï¿½ric Thiï¿½baut <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loï¿½c Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferrï¿½ol Soulez <ferreol.soulez@univ-lyon1.fr>
 %  *
 %  * This software is governed by the CeCILL-C license under French law and
 %  * abiding by the rules of distribution of free software.  You can use, modify

--- a/matlab/m_regul_totvar_2d.m
+++ b/matlab/m_regul_totvar_2d.m
@@ -1,0 +1,48 @@
+ 	
+%  function m_regul_totvar_2d
+% 
+%  [fx, gx] = m_regul_totvar_2d(x, w1, w2, eps, flags);
+%                                       
+%  MexFile to call from Matlab the rgl_tv2d function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  
+%  Compilation :
+%        mex m_regul_totvar_2d.c totvar.o
+%   
+%  Juillet 2015
+%  CEA-LETI
+%  Fabien Momey
+%   
+%  *-----------------------------------------------------------------------------
+%  * Information about totvar library
+%  *-----------------------------------------------------------------------------
+%  *
+%  * Copyright (C) 2010-2014, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  *
+%  * This software is governed by the CeCILL-C license under French law and
+%  * abiding by the rules of distribution of free software.  You can use, modify
+%  * and/or redistribute the software under the terms of the CeCILL-C license as
+%  * circulated by CEA, CNRS and INRIA at the following URL
+%  * "http://www.cecill.info".
+%  *
+%  * As a counterpart to the access to the source code and rights to copy,
+%  * modify and redistribute granted by the license, users are provided only
+%  * with a limited warranty and the software's author, the holder of the
+%  * economic rights, and the successive licensors have only limited liability.
+%  *
+%  * In this respect, the user's attention is drawn to the risks associated with
+%  * loading, using, modifying and/or developing or reproducing the software by
+%  * the user in light of its specific status of free software, that may mean
+%  * that it is complicated to manipulate, and that also therefore means that it
+%  * is reserved for developers and experienced professionals having in-depth
+%  * computer knowledge. Users are therefore encouraged to load and test the
+%  * software's suitability as regards their requirements in conditions enabling
+%  * the security of their systems and/or data to be ensured and, more
+%  * generally, to use and operate it in the same conditions as regards
+%  * security.
+%  *
+%  * The fact that you are presently reading this means that you have had
+%  * knowledge of the CeCILL-C license and that you accept its terms.
+%  *
+%  *-----------------------------------------------------------------------------

--- a/matlab/m_regul_totvar_2d_complex.c
+++ b/matlab/m_regul_totvar_2d_complex.c
@@ -1,0 +1,91 @@
+/* 	
+ function m_regul_totvar_2d_complex
+
+  [fx, gxr, gxi] = m_regul_totvar_2d_complex(xr, xi, w1, w2, eps, flags);
+                                      
+  MexFile to call from Matlab the rgl_tv2d_complex function of the Totvar library.
+ 
+  Compilation :
+        mex m_regul_totvar_2d_complex.c totvar.o
+  
+  Mai 2017
+  LaHC
+  Fabien Momey
+*/
+
+#include "matrix.h"
+#include "mex.h"
+#include "../totvar.h"
+
+void mexFunction( int nlhs1, mxArray *plhs[],    
+                  int nrhs, const mxArray *prhs[] )
+{ 
+    double w1, w2, eps;
+    mwSize n1, n2, nDims; 
+    const mwSize *pDims;
+    const mwSize pDims2[] = {1,1};
+    unsigned int flags; 
+    double *xr;
+    double *xi;
+
+    double *fx;
+    double *gxr; 
+    double *gxi; 
+
+    /* Control of the number of inputs and outputs */ 
+    if (nrhs > 6)
+        mexErrMsgTxt("6 input argument required."); 
+    else if (nlhs1 !=3) 
+        mexErrMsgTxt("3 output argument required.");
+    
+    /* Control of the inputs */
+	if (!mxIsNumeric(prhs[0]) || !mxIsDouble(prhs[0])) 
+        mexErrMsgTxt("The first input must be numerical double array.");
+    if (!mxIsNumeric(prhs[1]) || !mxIsDouble(prhs[1])) 
+        mexErrMsgTxt("The second input must be numerical double array.");
+    if (!mxIsNumeric(prhs[2]) || !mxIsScalar(prhs[2])
+        || !mxIsNumeric(prhs[3]) || !mxIsScalar(prhs[3]) 
+		|| !mxIsNumeric(prhs[4]) || !mxIsScalar(prhs[4])
+        || !mxIsNumeric(prhs[5]) || !mxIsScalar(prhs[5]) ) 
+        mexErrMsgTxt("The 4 last input must be scalar."); 
+    
+    if ( (double )(unsigned int )mxGetScalar(prhs[5]) != mxGetScalar(prhs[5]) )
+        mexErrMsgTxt("The last input flags must be an unsigned integer.");
+    
+    /* Get the inputs */
+    w1        = (double )mxGetScalar(prhs[2]);
+    w2        = (double )mxGetScalar(prhs[3]);
+    eps       = (double )mxGetScalar(prhs[4]);
+    flags     = (unsigned int )mxGetScalar(prhs[5]);
+    flags    |= RGL_INTEGRATE_GRADIENT;
+		
+    nDims = mxGetNumberOfDimensions(prhs[0]);
+    pDims = mxGetDimensions(prhs[0]);
+    xr = mxGetPr(prhs[0]);
+    
+    nDims = mxGetNumberOfDimensions(prhs[1]);
+    pDims = mxGetDimensions(prhs[1]);
+    xi = mxGetPr(prhs[1]);
+    
+    n1        = pDims[0];
+    n2        = pDims[1];
+
+    /* Display the inputs */
+    // mexPrintf("n1 = %d, n2 = %d, w1 = %f, w2 = %f, eps = %f, flags = %d\n", n1, n2, w1, w2, eps, flags);
+    
+    /* Create the output arguments */
+    /* Argument fx */
+    plhs[0] = mxCreateNumericArray(2, pDims2, mxDOUBLE_CLASS, mxREAL);
+    fx = mxGetPr(plhs[0]);
+    
+    /* Argument gxr */
+    plhs[1] = mxCreateNumericArray(nDims, pDims, mxDOUBLE_CLASS, mxREAL);
+    gxr = mxGetPr(plhs[1]);
+    
+    /* Argument gxi */
+    plhs[2] = mxCreateNumericArray(nDims, pDims, mxDOUBLE_CLASS, mxREAL);
+    gxi = mxGetPr(plhs[2]);
+   
+    /* Call to the rgl_tv2d_complex function */
+    *fx = rgl_tv2d_complex(xr,xi,n1,n2,w1,w2,eps,gxr,gxi,flags); 
+}

--- a/matlab/m_regul_totvar_2d_complex.c
+++ b/matlab/m_regul_totvar_2d_complex.c
@@ -62,16 +62,13 @@ void mexFunction( int nlhs1, mxArray *plhs[],
     nDims = mxGetNumberOfDimensions(prhs[0]);
     pDims = mxGetDimensions(prhs[0]);
     xr = mxGetPr(prhs[0]);
-    
-    nDims = mxGetNumberOfDimensions(prhs[1]);
-    pDims = mxGetDimensions(prhs[1]);
     xi = mxGetPr(prhs[1]);
     
     n1        = pDims[0];
     n2        = pDims[1];
 
     /* Display the inputs */
-    // mexPrintf("n1 = %d, n2 = %d, w1 = %f, w2 = %f, eps = %f, flags = %d\n", n1, n2, w1, w2, eps, flags);
+    /* mexPrintf("n1 = %d, n2 = %d, w1 = %f, w2 = %f, eps = %f, flags = %d\n", n1, n2, w1, w2, eps, flags); */
     
     /* Create the output arguments */
     /* Argument fx */

--- a/matlab/m_regul_totvar_2d_complex.c
+++ b/matlab/m_regul_totvar_2d_complex.c
@@ -3,10 +3,12 @@
 
   [fx, gxr, gxi] = m_regul_totvar_2d_complex(xr, xi, w1, w2, eps, flags);
                                       
-  MexFile to call from Matlab the rgl_tv2d_complex function of the Totvar library.
+  MexFile to call from Matlab the rgl_tv2d_complex function of the Totvar library
+  which implements Definitions for relaxed Total Variation (TV)
+  for images with complex values.
  
   Compilation :
-        mex m_regul_totvar_2d_complex.c totvar.o
+        mex m_regul_totvar_2d_complex.c ../totvar.o (or totvar.obj)
   
   Mai 2017
   LaHC

--- a/matlab/m_regul_totvar_2d_complex.m
+++ b/matlab/m_regul_totvar_2d_complex.m
@@ -3,7 +3,9 @@
 % 
 %  [fx, gxr, gxi] = m_regul_totvar_2d_complex(xr, xi, w1, w2, eps, flags);
 %                                       
-%  MexFile to call from Matlab the rgl_tv2d_complex function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  MexFile to call from Matlab the rgl_tv2d_complex function of the totvar library 
+%  which implements Definitions for relaxed Total Variation (TV)
+%  for images with complex values.
 %  
 %  Compilation :
 %        mex m_regul_totvar_2d_complex.c totvar.o

--- a/matlab/m_regul_totvar_2d_complex.m
+++ b/matlab/m_regul_totvar_2d_complex.m
@@ -1,0 +1,48 @@
+ 	
+%  function m_regul_totvar_2d_complex
+% 
+%  [fx, gxr, gxi] = m_regul_totvar_2d_complex(xr, xi, w1, w2, eps, flags);
+%                                       
+%  MexFile to call from Matlab the rgl_tv2d_complex function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  
+%  Compilation :
+%        mex m_regul_totvar_2d_complex.c totvar.o
+%   
+%  Mai 2017
+%  LaHC
+%  Fabien Momey
+%   
+%  *-----------------------------------------------------------------------------
+%  * Information about totvar library
+%  *-----------------------------------------------------------------------------
+%  *
+%  * Copyright (C) 2010-2014, Éric  <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  *
+%  * This software is governed by the CeCILL-C license under French law and
+%  * abiding by the rules of distribution of free software.  You can use, modify
+%  * and/or redistribute the software under the terms of the CeCILL-C license as
+%  * circulated by CEA, CNRS and INRIA at the following URL
+%  * "http://www.cecill.info".
+%  *
+%  * As a counterpart to the access to the source code and rights to copy,
+%  * modify and redistribute granted by the license, users are provided only
+%  * with a limited warranty and the software's author, the holder of the
+%  * economic rights, and the successive licensors have only limited liability.
+%  *
+%  * In this respect, the user's attention is drawn to the risks associated with
+%  * loading, using, modifying and/or developing or reproducing the software by
+%  * the user in light of its specific status of free software, that may mean
+%  * that it is complicated to manipulate, and that also therefore means that it
+%  * is reserved for developers and experienced professionals having in-depth
+%  * computer knowledge. Users are therefore encouraged to load and test the
+%  * software's suitability as regards their requirements in conditions enabling
+%  * the security of their systems and/or data to be ensured and, more
+%  * generally, to use and operate it in the same conditions as regards
+%  * security.
+%  *
+%  * The fact that you are presently reading this means that you have had
+%  * knowledge of the CeCILL-C license and that you accept its terms.
+%  *
+%  *-----------------------------------------------------------------------------

--- a/matlab/m_regul_totvar_2d_complex.m
+++ b/matlab/m_regul_totvar_2d_complex.m
@@ -8,7 +8,7 @@
 %  for images with complex values.
 %  
 %  Compilation :
-%        mex m_regul_totvar_2d_complex.c totvar.o
+%        mex m_regul_totvar_2d_complex.c ../totvar.o (or totvar.obj)
 %   
 %  Mai 2017
 %  LaHC

--- a/matlab/m_regul_totvar_3d.c
+++ b/matlab/m_regul_totvar_3d.c
@@ -3,10 +3,12 @@
 
   [fx, gx] = m_regul_totvar_3d(x, w1, w2, w3, eps, flags);
                                       
-  MexFile to call from Matlab the rgl_tv3d function of the Totvar library.
+  MexFile to call from Matlab the rgl_tv3d function of the Totvar library
+  which implements Definitions for relaxed Total Variation (TV)
+  for images with complex values.
  
   Compilation :
-        mex m_regul_totvar_3d.c totvar.obj
+        mex m_regul_totvar_3d.c ../totvar.o (or totvar.obj)
   
   Juillet 2015
   CEA-LETI
@@ -15,7 +17,7 @@
 
 #include "matrix.h"
 #include "mex.h"
-#include "totvar.h"
+#include "../totvar.h"
 
 void mexFunction( int nlhs1, mxArray *plhs[],    
                   int nrhs, const mxArray *prhs[] )
@@ -32,7 +34,7 @@ void mexFunction( int nlhs1, mxArray *plhs[],
 
     /* Control of the number of inputs and outputs */ 
     if (nrhs > 6)
-        mexErrMsgTxt("9 input argument required."); 
+        mexErrMsgTxt("6 input argument required."); 
     else if (nlhs1 !=2) 
         mexErrMsgTxt("2 output argument required.");
     
@@ -66,7 +68,7 @@ void mexFunction( int nlhs1, mxArray *plhs[],
 	n3        = pDims[2];
 
     /* Display the inputs */
-    // mexPrintf("n1 = %d, n2 = %d, n3 = %d, w1 = %f, w2 = %f, w3 = %f, eps = %f, flags = %d\n", n1, n2, n3, w1, w2, w3, eps, flags);
+    /* mexPrintf("n1 = %d, n2 = %d, n3 = %d, w1 = %f, w2 = %f, w3 = %f, eps = %f, flags = %d\n", n1, n2, n3, w1, w2, w3, eps, flags); */
     
     /* Create the output arguments */
     /* Argument fx */

--- a/matlab/m_regul_totvar_3d.c
+++ b/matlab/m_regul_totvar_3d.c
@@ -1,0 +1,82 @@
+/* 	
+ function m_regul_totvar_3d
+
+  [fx, gx] = m_regul_totvar_3d(x, w1, w2, w3, eps, flags);
+                                      
+  MexFile to call from Matlab the rgl_tv3d function of the Totvar library.
+ 
+  Compilation :
+        mex m_regul_totvar_3d.c totvar.obj
+  
+  Juillet 2015
+  CEA-LETI
+  Fabien Momey
+*/
+
+#include "matrix.h"
+#include "mex.h"
+#include "totvar.h"
+
+void mexFunction( int nlhs1, mxArray *plhs[],    
+                  int nrhs, const mxArray *prhs[] )
+{ 
+    double w1, w2, w3, eps;
+    mwSize n1, n2, n3, nDims; 
+    const mwSize *pDims;
+    const mwSize pDims2[] = {1,1};
+	unsigned int flags; 
+	double *x;
+
+    double *fx;
+    double *gx; 
+
+    /* Control of the number of inputs and outputs */ 
+    if (nrhs > 6)
+        mexErrMsgTxt("9 input argument required."); 
+    else if (nlhs1 !=2) 
+        mexErrMsgTxt("2 output argument required.");
+    
+    /* Control of the inputs */
+	if (!mxIsNumeric(prhs[0]) || !mxIsDouble(prhs[0])) 
+        mexErrMsgTxt("The first input must be numerical double array.");
+    if (!mxIsNumeric(prhs[1]) || !mxIsScalar(prhs[1])
+        || !mxIsNumeric(prhs[2]) || !mxIsScalar(prhs[2]) 
+		|| !mxIsNumeric(prhs[3]) || !mxIsScalar(prhs[3])
+        || !mxIsNumeric(prhs[4]) || !mxIsScalar(prhs[4]) 
+		|| !mxIsNumeric(prhs[5]) || !mxIsScalar(prhs[5]) ) 
+        mexErrMsgTxt("The 5 last input must be scalar."); 
+    
+    if ( (double )(unsigned int )mxGetScalar(prhs[5]) != mxGetScalar(prhs[5]) )
+        mexErrMsgTxt("The last input flags must be an unsigned integer.");
+    
+    /* Get the inputs */
+    w1        = (double )mxGetScalar(prhs[1]);
+    w2        = (double )mxGetScalar(prhs[2]);
+	w3        = (double )mxGetScalar(prhs[3]);
+    eps       = (double )mxGetScalar(prhs[4]);
+    flags     = (unsigned int )mxGetScalar(prhs[5]);
+    flags    |= RGL_INTEGRATE_GRADIENT;
+		
+	nDims = mxGetNumberOfDimensions(prhs[0]);
+    pDims = mxGetDimensions(prhs[0]);
+    x = mxGetPr(prhs[0]);	
+    
+    n1        = pDims[0];
+    n2        = pDims[1];
+	n3        = pDims[2];
+
+    /* Display the inputs */
+    // mexPrintf("n1 = %d, n2 = %d, n3 = %d, w1 = %f, w2 = %f, w3 = %f, eps = %f, flags = %d\n", n1, n2, n3, w1, w2, w3, eps, flags);
+    
+    /* Create the output arguments */
+    /* Argument fx */
+    plhs[0] = mxCreateNumericArray(2, pDims2, mxDOUBLE_CLASS, mxREAL);
+    fx = mxGetPr(plhs[0]);
+    
+    /* Argument gx */
+    plhs[1] = mxCreateNumericArray(nDims, pDims, mxDOUBLE_CLASS, mxREAL);
+    gx = mxGetPr(plhs[1]);
+   
+    /* Call to the rgl_tv3d function */
+    *fx = rgl_tv3d(x,n1,n2,n3,w1,w2,w3,eps,gx,flags); 
+}

--- a/matlab/m_regul_totvar_3d.m
+++ b/matlab/m_regul_totvar_3d.m
@@ -1,0 +1,48 @@
+ 	
+%  function m_regul_totvar_3d
+% 
+%  [fx, gx] = m_regul_totvar_3d(x, w1, w2, w3, eps, flags);
+%                                       
+%  MexFile to call from Matlab the rgl_tv3d function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  
+%  Compilation :
+%        mex m_regul_totvar_3d.c totvar.obj
+%   
+%  Juillet 2015
+%  CEA-LETI
+%  Fabien Momey
+%   
+%  *-----------------------------------------------------------------------------
+%  * Information about totvar library
+%  *-----------------------------------------------------------------------------
+%  *
+%  * Copyright (C) 2010-2014, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  *
+%  * This software is governed by the CeCILL-C license under French law and
+%  * abiding by the rules of distribution of free software.  You can use, modify
+%  * and/or redistribute the software under the terms of the CeCILL-C license as
+%  * circulated by CEA, CNRS and INRIA at the following URL
+%  * "http://www.cecill.info".
+%  *
+%  * As a counterpart to the access to the source code and rights to copy,
+%  * modify and redistribute granted by the license, users are provided only
+%  * with a limited warranty and the software's author, the holder of the
+%  * economic rights, and the successive licensors have only limited liability.
+%  *
+%  * In this respect, the user's attention is drawn to the risks associated with
+%  * loading, using, modifying and/or developing or reproducing the software by
+%  * the user in light of its specific status of free software, that may mean
+%  * that it is complicated to manipulate, and that also therefore means that it
+%  * is reserved for developers and experienced professionals having in-depth
+%  * computer knowledge. Users are therefore encouraged to load and test the
+%  * software's suitability as regards their requirements in conditions enabling
+%  * the security of their systems and/or data to be ensured and, more
+%  * generally, to use and operate it in the same conditions as regards
+%  * security.
+%  *
+%  * The fact that you are presently reading this means that you have had
+%  * knowledge of the CeCILL-C license and that you accept its terms.
+%  *
+%  *-----------------------------------------------------------------------------

--- a/matlab/m_regul_totvar_3d.m
+++ b/matlab/m_regul_totvar_3d.m
@@ -3,10 +3,11 @@
 % 
 %  [fx, gx] = m_regul_totvar_3d(x, w1, w2, w3, eps, flags);
 %                                       
-%  MexFile to call from Matlab the rgl_tv3d function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  MexFile to call from Matlab the rgl_tv3d function of the totvar library
+%  which implements Definitions for relaxed Total Variation (TV)
 %  
 %  Compilation :
-%        mex m_regul_totvar_3d.c totvar.obj
+%        mex m_regul_totvar_3d.c ../totvar.o (or totvar.obj)
 %   
 %  Juillet 2015
 %  CEA-LETI
@@ -16,9 +17,9 @@
 %  * Information about totvar library
 %  *-----------------------------------------------------------------------------
 %  *
-%  * Copyright (C) 2010-2014, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>,
-%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
-%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  * Copyright (C) 2010-2014, ï¿½ric Thiï¿½baut <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loï¿½c Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferrï¿½ol Soulez <ferreol.soulez@univ-lyon1.fr>
 %  *
 %  * This software is governed by the CeCILL-C license under French law and
 %  * abiding by the rules of distribution of free software.  You can use, modify

--- a/matlab/m_regul_totvar_3d_complex.c
+++ b/matlab/m_regul_totvar_3d_complex.c
@@ -3,10 +3,12 @@
 
   [fx, gxr, gxi] = m_regul_totvar_3d_complex(xr, xi, w1, w2, w3, eps, flags);
                                       
-  MexFile to call from Matlab the rgl_tv3d function of the Totvar library.
+  MexFile to call from Matlab the rgl_tv3d function of the Totvar library
+  which implements Definitions for relaxed Total Variation (TV)
+  for images with complex values.
  
   Compilation :
-        mex m_regul_totvar_3d_complex.c totvar.obj
+        mex m_regul_totvar_3d_complex.c ../totvar.o (or totvar.obj)
   
   Juillet 2015
   CEA-LETI
@@ -15,7 +17,7 @@
 
 #include "matrix.h"
 #include "mex.h"
-#include "totvar.h"
+#include "../totvar.h"
 
 void mexFunction( int nlhs1, mxArray *plhs[],    
                   int nrhs, const mxArray *prhs[] )
@@ -34,7 +36,7 @@ void mexFunction( int nlhs1, mxArray *plhs[],
 
     /* Control of the number of inputs and outputs */ 
     if (nrhs > 7)
-        mexErrMsgTxt("10 input argument required."); 
+        mexErrMsgTxt("7 input argument required."); 
     else if (nlhs1 !=3) 
         mexErrMsgTxt("3 output argument required.");
     
@@ -65,8 +67,6 @@ void mexFunction( int nlhs1, mxArray *plhs[],
     pDims = mxGetDimensions(prhs[0]);
     xr = mxGetPr(prhs[0]);
     
-    nDims = mxGetNumberOfDimensions(prhs[1]);
-    pDims = mxGetDimensions(prhs[1]);
     xi = mxGetPr(prhs[1]);
     
     n1        = pDims[0];
@@ -74,7 +74,7 @@ void mexFunction( int nlhs1, mxArray *plhs[],
 	n3        = pDims[2];
 
     /* Display the inputs */
-    // mexPrintf("n1 = %d, n2 = %d, n3 = %d, w1 = %f, w2 = %f, w3 = %f, eps = %f, flags = %d\n", n1, n2, n3, w1, w2, w3, eps, flags);
+    /* mexPrintf("n1 = %d, n2 = %d, n3 = %d, w1 = %f, w2 = %f, w3 = %f, eps = %f, flags = %d\n", n1, n2, n3, w1, w2, w3, eps, flags); */
     
     /* Create the output arguments */
     /* Argument fx */

--- a/matlab/m_regul_totvar_3d_complex.c
+++ b/matlab/m_regul_totvar_3d_complex.c
@@ -1,0 +1,94 @@
+/* 	
+ function m_regul_totvar_3d_complex
+
+  [fx, gxr, gxi] = m_regul_totvar_3d_complex(xr, xi, w1, w2, w3, eps, flags);
+                                      
+  MexFile to call from Matlab the rgl_tv3d function of the Totvar library.
+ 
+  Compilation :
+        mex m_regul_totvar_3d_complex.c totvar.obj
+  
+  Juillet 2015
+  CEA-LETI
+  Fabien Momey
+*/
+
+#include "matrix.h"
+#include "mex.h"
+#include "totvar.h"
+
+void mexFunction( int nlhs1, mxArray *plhs[],    
+                  int nrhs, const mxArray *prhs[] )
+{ 
+    double w1, w2, w3, eps;
+    mwSize n1, n2, n3, nDims; 
+    const mwSize *pDims;
+    const mwSize pDims2[] = {1,1};
+	unsigned int flags; 
+	double *xr;
+    double *xi;
+
+    double *fx;
+    double *gxr; 
+    double *gxi; 
+
+    /* Control of the number of inputs and outputs */ 
+    if (nrhs > 7)
+        mexErrMsgTxt("10 input argument required."); 
+    else if (nlhs1 !=3) 
+        mexErrMsgTxt("3 output argument required.");
+    
+    /* Control of the inputs */
+	if (!mxIsNumeric(prhs[0]) || !mxIsDouble(prhs[0])) 
+        mexErrMsgTxt("The first input must be numerical double array.");
+    if (!mxIsNumeric(prhs[1]) || !mxIsDouble(prhs[1])) 
+        mexErrMsgTxt("The second input must be numerical double array.");
+    if (!mxIsNumeric(prhs[2]) || !mxIsScalar(prhs[2])
+        || !mxIsNumeric(prhs[3]) || !mxIsScalar(prhs[3]) 
+		|| !mxIsNumeric(prhs[4]) || !mxIsScalar(prhs[4])
+        || !mxIsNumeric(prhs[5]) || !mxIsScalar(prhs[5]) 
+		|| !mxIsNumeric(prhs[6]) || !mxIsScalar(prhs[6]) ) 
+        mexErrMsgTxt("The 5 last input must be scalar."); 
+    
+    if ( (double )(unsigned int )mxGetScalar(prhs[6]) != mxGetScalar(prhs[6]) )
+        mexErrMsgTxt("The last input flags must be an unsigned integer.");
+    
+    /* Get the inputs */
+    w1        = (double )mxGetScalar(prhs[2]);
+    w2        = (double )mxGetScalar(prhs[3]);
+	w3        = (double )mxGetScalar(prhs[4]);
+    eps       = (double )mxGetScalar(prhs[5]);
+    flags     = (unsigned int )mxGetScalar(prhs[6]);
+    flags    |= RGL_INTEGRATE_GRADIENT;
+		
+	nDims = mxGetNumberOfDimensions(prhs[0]);
+    pDims = mxGetDimensions(prhs[0]);
+    xr = mxGetPr(prhs[0]);
+    
+    nDims = mxGetNumberOfDimensions(prhs[1]);
+    pDims = mxGetDimensions(prhs[1]);
+    xi = mxGetPr(prhs[1]);
+    
+    n1        = pDims[0];
+    n2        = pDims[1];
+	n3        = pDims[2];
+
+    /* Display the inputs */
+    // mexPrintf("n1 = %d, n2 = %d, n3 = %d, w1 = %f, w2 = %f, w3 = %f, eps = %f, flags = %d\n", n1, n2, n3, w1, w2, w3, eps, flags);
+    
+    /* Create the output arguments */
+    /* Argument fx */
+    plhs[0] = mxCreateNumericArray(2, pDims2, mxDOUBLE_CLASS, mxREAL);
+    fx = mxGetPr(plhs[0]);
+    
+    /* Argument gxr */
+    plhs[1] = mxCreateNumericArray(nDims, pDims, mxDOUBLE_CLASS, mxREAL);
+    gxr = mxGetPr(plhs[1]);
+    
+    /* Argument gxi */
+    plhs[2] = mxCreateNumericArray(nDims, pDims, mxDOUBLE_CLASS, mxREAL);
+    gxi = mxGetPr(plhs[2]);
+   
+    /* Call to the rgl_tv3d function */
+    *fx = rgl_tv3d_complex(xr,xi,n1,n2,n3,w1,w2,w3,eps,gxr,gxi,flags); 
+}

--- a/matlab/m_regul_totvar_3d_complex.m
+++ b/matlab/m_regul_totvar_3d_complex.m
@@ -3,10 +3,12 @@
 % 
 %  [fx, gxr, gxi] = m_regul_totvar_3d_complex(xr, xi, w1, w2, w3, eps, flags);
 %                                       
-%  MexFile to call from Matlab the rgl_tv3d_complex function of the totvar library which implements Definitions for relaxed Total Variation (TV).
-%  
+%  MexFile to call from Matlab the rgl_tv3d_complex function of the totvar library
+%  which implements Definitions for relaxed Total Variation (TV)
+%  for images with complex values.
+%
 %  Compilation :
-%        mex m_regul_totvar_3d_complex.c totvar.obj
+%        mex m_regul_totvar_3d_complex.c ../totvar.o (or totvar.obj)
 %   
 %  Juillet 2015
 %  CEA-LETI
@@ -16,9 +18,9 @@
 %  * Information about totvar library
 %  *-----------------------------------------------------------------------------
 %  *
-%  * Copyright (C) 2010-2014, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>,
-%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
-%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  * Copyright (C) 2010-2014, ï¿½ric Thiï¿½baut <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loï¿½c Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferrï¿½ol Soulez <ferreol.soulez@univ-lyon1.fr>
 %  *
 %  * This software is governed by the CeCILL-C license under French law and
 %  * abiding by the rules of distribution of free software.  You can use, modify

--- a/matlab/m_regul_totvar_3d_complex.m
+++ b/matlab/m_regul_totvar_3d_complex.m
@@ -1,0 +1,48 @@
+ 	
+%  function m_regul_totvar_3d_complex
+% 
+%  [fx, gxr, gxi] = m_regul_totvar_3d_complex(xr, xi, w1, w2, w3, eps, flags);
+%                                       
+%  MexFile to call from Matlab the rgl_tv3d_complex function of the totvar library which implements Definitions for relaxed Total Variation (TV).
+%  
+%  Compilation :
+%        mex m_regul_totvar_3d_complex.c totvar.obj
+%   
+%  Juillet 2015
+%  CEA-LETI
+%  Fabien Momey
+%   
+%  *-----------------------------------------------------------------------------
+%  * Information about totvar library
+%  *-----------------------------------------------------------------------------
+%  *
+%  * Copyright (C) 2010-2014, Éric Thiébaut <eric.thiebaut@univ-lyon1.fr>,
+%  *                          Loïc Denis <loic.denis@univ-st-etienne.fr>,
+%  *                          Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+%  *
+%  * This software is governed by the CeCILL-C license under French law and
+%  * abiding by the rules of distribution of free software.  You can use, modify
+%  * and/or redistribute the software under the terms of the CeCILL-C license as
+%  * circulated by CEA, CNRS and INRIA at the following URL
+%  * "http://www.cecill.info".
+%  *
+%  * As a counterpart to the access to the source code and rights to copy,
+%  * modify and redistribute granted by the license, users are provided only
+%  * with a limited warranty and the software's author, the holder of the
+%  * economic rights, and the successive licensors have only limited liability.
+%  *
+%  * In this respect, the user's attention is drawn to the risks associated with
+%  * loading, using, modifying and/or developing or reproducing the software by
+%  * the user in light of its specific status of free software, that may mean
+%  * that it is complicated to manipulate, and that also therefore means that it
+%  * is reserved for developers and experienced professionals having in-depth
+%  * computer knowledge. Users are therefore encouraged to load and test the
+%  * software's suitability as regards their requirements in conditions enabling
+%  * the security of their systems and/or data to be ensured and, more
+%  * generally, to use and operate it in the same conditions as regards
+%  * security.
+%  *
+%  * The fact that you are presently reading this means that you have had
+%  * knowledge of the CeCILL-C license and that you accept its terms.
+%  *
+%  *-----------------------------------------------------------------------------

--- a/totvar.c
+++ b/totvar.c
@@ -544,6 +544,181 @@ double rgl_tv2d(const double x[], const long n1, const long n2,
   return fx;
 }
 
+double rgl_tv2d_complex(const double xr[], const double xi[],
+                       const long n1, const long n2,
+                       const double w1, const double w2,
+                       const double eps, double gxr[], double gxi[],
+                       unsigned int flags)
+{
+  const double ZERO = 0.0;
+  double x1r, x2r, x3r, x4r, y1r, y2r, y3r;
+  double x1i, x2i, x3i, x4i, y1i, y2i, y3i;
+  double p, r, s, fx;
+  long i1, i2, j1, j2, j3, j4;
+  int compute_gradient;
+
+  compute_gradient = ((flags & COMPUTE_GRADIENT) != 0);
+  if (xr == NULL || xi ==NULL || n1 < 0 || n2 < 0 || w1 < 0.0 || w2 < 0.0 || eps < 0.0 ||
+      (gxr == NULL && compute_gradient) || (gxi == NULL && compute_gradient)) {
+    return -1.0;
+  }
+  if ((flags & RGL_STORE_GRADIENT) != 0) {
+    memset(gxr, 0, n1*n2*sizeof(gxr[0]));
+    memset(gxi, 0, n1*n2*sizeof(gxi[0]));
+  }
+  fx = 0.0;
+  s = eps*eps;
+
+#define  X(a1,a2)   x[OFF2(a1,a2)]
+#define GX(a1,a2)  gx[OFF2(a1,a2)]
+
+  if (METHOD(flags, RGL_TOTVAR_ISOTROPIC)) {
+    /*
+     * Assume RGL_TOTVAR_ISOTROPIC.
+     *
+     * The squared norm of the spatial gradient is the sum of the
+     * squared differences along all the edges (divided by 2).
+     */
+
+    double y12r, y34r, y13r, y24r;
+    double y12i, y34i, y13i, y24i;
+
+    if (w1 == w2) /* same weights along all directions */ {
+      double q = w1/2.0;
+      if (compute_gradient) {
+        double p;
+        for (i2 = 1; i2 < n2; ++i2) {
+          j2 = OFF2(0, i2 - 1);
+          j4 = OFF2(0, i2);
+          x2r = xr[j2]; x2i = xi[j2]; 
+          x4r = xr[j4]; x4i = xi[j4];
+          for (i1 = 1; i1 < n1; ++i1) {
+            j1 = j2++;
+            j3 = j4++;
+            x1r = x2r;     x1i = x2i;
+            x2r = xr[j2];  x2i = xi[j2];
+            x3r = x4r;     x3i = x4i;
+            x4r = xr[j4];  x4i = xi[j4];
+            y12r = x1r - x2r;  y12i = x1i - x2i;
+            y34r = x3r - x4r;  y34i = x3i - x4i;
+            y13r = x1r - x3r;  y13i = x1i - x3i;
+            y24r = x2r - x4r;  y24i = x2i - x4i;
+            r = (SQ(y12r) + SQ(y34r) + SQ(y13r) + SQ(y24r) +
+                 SQ(y12i) + SQ(y34i) + SQ(y13i) + SQ(y24i))*q;
+            p = sqrt(r + s);
+            fx += p;
+            p = q/p;
+            gxr[j1] += (y12r + y13r)*p;
+            gxr[j2] -= (y12r - y24r)*p;
+            gxr[j3] += (y34r - y13r)*p;
+            gxr[j4] -= (y34r + y24r)*p;
+            gxi[j1] += (y12i + y13i)*p;
+            gxi[j2] -= (y12i - y24i)*p;
+            gxi[j3] += (y34i - y13i)*p;
+            gxi[j4] -= (y34i + y24i)*p;
+          }
+        }
+      } else /* do not compute gradient */ {
+        for (i2 = 1; i2 < n2; ++i2) {
+          j2 = OFF2(0, i2 - 1);
+          j4 = OFF2(0, i2);
+          x2r = xr[j2]; x2i = xi[j2];
+          x4r = xr[j4]; x4i = xi[j4];
+          for (i1 = 1; i1 < n1; ++i1) {
+            j2++;
+            j4++;
+            x1r = x2r;       x1i = x2i;
+            x2r = xr[j2];  x2i = xi[j2];
+            x3r = x4r;       x3i = x4i;
+            x4r = xr[j4];  x4i = xi[j4];
+            y12r = x1r - x2r;  y12i = x1i - x2i;
+            y34r = x3r - x4r;  y34i = x3i - x4i;
+            y13r = x1r - x3r;  y13i = x1i - x3i;
+            y24r = x2r - x4r;  y24i = x2i - x4i;
+            r = (SQ(y12r) + SQ(y34r) + SQ(y13r) + SQ(y24r) +
+                 SQ(y12i) + SQ(y34i) + SQ(y13i) + SQ(y24i))*q;
+            fx += sqrt(r + s);
+          }
+        }
+      }
+    } else /* not same weights along all directions */ {
+      double q1 = w1/2.0, q2 = w2/2.0;
+      if (compute_gradient) {
+        double p1, p2;
+        for (i2 = 1; i2 < n2; ++i2) {
+          j2 = OFF2(0, i2 - 1);
+          j4 = OFF2(0, i2);
+          x2r = xr[j2];  x2i = xi[j2];
+          x4r = xr[j4];  x4i = xi[j4];
+          for (i1 = 1; i1 < n1; ++i1) {
+            j1 = j2++;
+            j3 = j4++;
+            x1r = x2r;     x1i = x2i;
+            x2r = xr[j2];  x2i = xi[j2];
+            x3r = x4r;     x3i = x4i;
+            x4r = xr[j4];  x4i = xi[j4];
+            y12r = x1r - x2r;  y12i = x1i - x2i;
+            y34r = x3r - x4r;  y34i = x3i - x4i;
+            y13r = x1r - x3r;  y13i = x1i - x3i;
+            y24r = x2r - x4r;  y24i = x2i - x4i;
+            r = (SQ(y12r) + SQ(y34r))*q1 + (SQ(y13r) + SQ(y24r))*q2 +
+              (SQ(y12i) + SQ(y34i))*q1 + (SQ(y13i) + SQ(y24i))*q2;
+            r = sqrt(r + s);
+            fx += r;
+            r = 1.0/r;
+            p1 = r*q1;
+            p2 = r*q2;
+            y12r *= p1; y12i *= p1;
+            y34r *= p1; y34i *= p1;
+            y13r *= p2; y13i *= p2;
+            y24r *= p2; y24i *= p2;
+            gxr[j1] += y12r + y13r;
+            gxr[j2] -= y12r - y24r;
+            gxr[j3] += y34r - y13r;
+            gxr[j4] -= y34r + y24r;
+            gxi[j1] += y12i + y13i;
+            gxi[j2] -= y12i - y24i;
+            gxi[j3] += y34i - y13i;
+            gxi[j4] -= y34i + y24i;
+          }
+        }
+      } else /* do not compute gradient */ {
+        for (i2 = 1; i2 < n2; ++i2) {
+          j2 = OFF2(0, i2 - 1);
+          j4 = OFF2(0, i2);
+          x2r = xr[j2]; x2i = xi[j2];
+          x4r = xr[j4]; x4i = xi[j4];
+          for (i1 = 1; i1 < n1; ++i1) {
+            j2++;
+            j4++;
+            x1r = x2r;     x1i = x2i;
+            x2r = xr[j2];  x2i = xi[j2];
+            x3r = x4r;     x3i = x4i;
+            x4r = xr[j4];  x4i = xi[j4];
+            y12r = x1r - x2r;  y12i = x1i - x2i;
+            y34r = x3r - x4r;  y34i = x3i - x4i;
+            y13r = x1r - x3r;  y13i = x1i - x3i;
+            y24r = x2r - x4r;  y24i = x2i - x4i;
+            r = (SQ(y12r) + SQ(y34r))*q1 + (SQ(y13r) + SQ(y24r))*q2 +
+              (SQ(y12i) + SQ(y34i))*q1 + (SQ(y13i) + SQ(y24i))*q2;
+            fx += sqrt(r + s);
+          }
+        }
+      }
+    }
+  }
+
+#undef X
+#undef GX
+
+  /* Remove the "bias" and make sure the result is non-negative (it can only
+     be negative due to rounding errors). */
+  fx -= (n1 - 1)*(n2 - 1)*eps;
+  if (fx < 0.0) {
+    fx = 0.0;
+  }
+  return fx;
+}
 
 /*
  * NOTATIONS FOR 3-D VOLUME X(i1,i2,i3)
@@ -927,6 +1102,309 @@ double rgl_tv3d(const double x[],
               r = ((SQ(y12) + SQ(y34) + SQ(y56) + SQ(y78))*q1 +
                    (SQ(y13) + SQ(y24) + SQ(y57) + SQ(y68))*q2 +
                    (SQ(y15) + SQ(y26) + SQ(y37) + SQ(y48))*q3);
+              fx += sqrt(r + s);
+            }
+          }
+        }
+      }
+    }
+
+  }
+
+  /* Remove the "bias" and make sure the result is non-negative (it can only
+     be negative due to rounding errors). */
+  fx -= (n1 - 1)*(n2 - 1)*(n3 - 1)*eps;
+  if (fx < 0.0) {
+    fx = 0.0;
+  }
+  return fx;
+}
+
+/*
+ * NOTATIONS FOR 3-D VOLUME X(i1,i2,i3)
+ *
+ *                 i3  i2
+ *                  | /
+ *                  |/              X1 = X(i1-1,i2-1,i3-1)
+ *        X7--------X8---> i1       X2 = X(i1  ,i2-1,i3-1)
+ *       /:        /|               X3 = X(i1-1,i2  ,i3-1)
+ *      / :       / |               X4 = X(i1  ,i2  ,i3-1)
+ *     X5--------X6 |               X5 = X(i1-1,i2-1,i3  )
+ *     |  X3.....|..X4              X6 = X(i1  ,i2-1,i3  )
+ *     | '       | /                X7 = X(i1-1,i2  ,i3  )
+ *     |'        |/                 X8 = X(i1  ,i2  ,i3  )
+ *     X1--------X2
+ *
+ */
+double rgl_tv3d_complex(const double xr[], const double xi[],
+                const long n1, const long n2, const long n3,
+                const double w1, const double w2, const double w3,
+                const double eps, double gxr[], double gxi[], unsigned int flags)
+{
+  double x1r, x2r, x3r, x4r, x5r, x6r, x7r, x8r;
+  double x1i, x2i, x3i, x4i, x5i, x6i, x7i, x8i;
+  double r, s, fx;
+  double y12r, y34r, y56r, y78r;
+  double y13r, y24r, y57r, y68r;
+  double y15r, y26r, y37r, y48r;
+  double y12i, y34i, y56i, y78i;
+  double y13i, y24i, y57i, y68i;
+  double y15i, y26i, y37i, y48i;
+  long i1, i2, i3;
+  long j1, j2, j3, j4, j5, j6, j7, j8;
+  int compute_gradient;
+
+  compute_gradient = ((flags & COMPUTE_GRADIENT) != 0);
+  if (xr == NULL || xi == NULL || n1 < 0 || n2 < 0 || n3 < 0 ||
+      w1 < 0.0 || w2 < 0.0 || w3 < 0.0 || eps < 0.0 ||
+      (gxr == NULL && compute_gradient) || (gxi == NULL && compute_gradient)) {
+    return -1.0;
+  }
+  if ((flags & RGL_STORE_GRADIENT) != 0) {
+    memset(gxr, 0, n1*n2*n3*sizeof(gxr[0]));
+    memset(gxi, 0, n1*n2*n3*sizeof(gxi[0]));
+  }
+  fx = 0.0;
+  s = eps*eps;
+
+  if (METHOD(flags, RGL_TOTVAR_ISOTROPIC)) {
+
+    /*
+     * The squared norm of the spatial gradient is the sum of the squared
+     * differences along all egdes of the 2x2x2 cube divided by 4 (isotropic
+     * definition).
+     */
+
+    if (w1 == w2 && w2 == w3) /* same weights along all directions */ {
+      double p, q = w1/4.0;
+      if (compute_gradient) {
+        for (i3 = 1; i3 < n3; ++i3) {
+          for (i2 = 1; i2 < n2; ++i2) {
+            j8 = OFF3(0, i2,   i3);
+            j6 = OFF3(0, i2-1, i3);
+            j4 = OFF3(0, i2,   i3-1);
+            j2 = OFF3(0, i2-1, i3-1);
+            x2r = xr[j2]; x2i = xi[j2]; 
+            x4r = xr[j4]; x4i = xi[j4];
+            x6r = xr[j6]; x6i = xi[j6];
+            x8r = xr[j8]; x8i = xi[j8];
+            for (i1 = 1; i1 < n1; ++i1) {
+              /* Peak the values at the 8 corners of the cube */
+              j1 = j2++; x1r = x2r; x2r = xr[j2]; x1i = x2i; x2i = xi[j2];
+              j3 = j4++; x3r = x4r; x4r = xr[j4]; x3i = x4i; x4i = xi[j4];
+              j5 = j6++; x5r = x6r; x6r = xr[j6]; x5i = x6i; x6i = xi[j6];
+              j7 = j8++; x7r = x8r; x8r = xr[j8]; x7i = x8i; x8i = xi[j8];
+              /* Compute the differences along all the 12 edges of the cube: */
+              /*  - along 1st dim: */
+              y12r = x1r - x2r; y12i = x1i - x2i;
+              y34r = x3r - x4r; y34i = x3i - x4i;
+              y56r = x5r - x6r; y56i = x5i - x6i;
+              y78r = x7r - x8r; y78i = x7i - x8i;
+              /*  - along 2nd dim: */
+              y13r = x1r - x3r; y13i = x1i - x3i;
+              y24r = x2r - x4r; y24i = x2i - x4i;
+              y57r = x5r - x7r; y57i = x5i - x7i;
+              y68r = x6r - x8r; y68i = x6i - x8i;
+              /*  - along 3rd dim: */
+              y15r = x1r - x5r; y15i = x1i - x5i;
+              y26r = x2r - x6r; y26i = x2i - x6i;
+              y37r = x3r - x7r; y37i = x3i - x7i;
+              y48r = x4r - x8r; y48i = x4i - x8i;
+              /* Compute the cost and integrate its gradient. */
+              r = (SQ(y12r) + SQ(y34r) + SQ(y56r) + SQ(y78r) +
+                   SQ(y13r) + SQ(y24r) + SQ(y57r) + SQ(y68r) +
+                   SQ(y15r) + SQ(y26r) + SQ(y37r) + SQ(y48r) +
+                   SQ(y12i) + SQ(y34i) + SQ(y56i) + SQ(y78i) +
+                   SQ(y13i) + SQ(y24i) + SQ(y57i) + SQ(y68i) +
+                   SQ(y15i) + SQ(y26i) + SQ(y37i) + SQ(y48i))*q;
+              p = sqrt(r + s);
+              fx += p;
+              p = q/p;
+              gxr[j1] += (y12r + y13r + y15r)*p;
+              gxr[j2] -= (y12r - y24r - y26r)*p;
+              gxr[j3] += (y34r - y13r + y37r)*p;
+              gxr[j4] -= (y34r + y24r - y48r)*p;
+              gxr[j5] += (y56r + y57r - y15r)*p;
+              gxr[j6] -= (y56r - y68r + y26r)*p;
+              gxr[j7] += (y78r - y57r - y37r)*p;
+              gxr[j8] -= (y78r + y68r + y48r)*p;
+              gxi[j1] += (y12i + y13i + y15i)*p;
+              gxi[j2] -= (y12i - y24i - y26i)*p;
+              gxi[j3] += (y34i - y13i + y37i)*p;
+              gxi[j4] -= (y34i + y24i - y48i)*p;
+              gxi[j5] += (y56i + y57i - y15i)*p;
+              gxi[j6] -= (y56i - y68i + y26i)*p;
+              gxi[j7] += (y78i - y57i - y37i)*p;
+              gxi[j8] -= (y78i + y68i + y48i)*p;
+            }
+          }
+        }
+      } else /* do not compute gradients */ {
+        for (i3 = 1; i3 < n3; ++i3) {
+          for (i2 = 1; i2 < n2; ++i2) {
+            j8 = OFF3(0, i2,   i3);
+            j6 = OFF3(0, i2-1, i3);
+            j4 = OFF3(0, i2,   i3-1);
+            j2 = OFF3(0, i2-1, i3-1);
+            x2r = xr[j2]; x2i = xi[j2]; 
+            x4r = xr[j4]; x4i = xi[j4];
+            x6r = xr[j6]; x6i = xi[j6];
+            x8r = xr[j8]; x8i = xi[j8];
+            for (i1 = 1; i1 < n1; ++i1) {
+              /* Peak the values at the 8 corners of the cube */
+              x1r = x2r; x2r = xr[++j2]; x1i = x2i; x2i = xi[++j2];
+              x3r = x4r; x4r = xr[++j4]; x3i = x4i; x4i = xi[++j4];
+              x5r = x6r; x6r = xr[++j6]; x5i = x6i; x6i = xi[++j6];
+              x7r = x8r; x8r = xr[++j8]; x7i = x8i; x8i = xi[++j8];
+              /* Compute the differences along all the 12 edges of the cube: */
+              /*  - along 1st dim: */
+              y12r = x1r - x2r; y12i = x1i - x2i;
+              y34r = x3r - x4r; y34i = x3i - x4i;
+              y56r = x5r - x6r; y56i = x5i - x6i;
+              y78r = x7r - x8r; y78i = x7i - x8i;
+              /*  - along 2nd dim: */
+              y13r = x1r - x3r; y13i = x1i - x3i;
+              y24r = x2r - x4r; y24i = x2i - x4i;
+              y57r = x5r - x7r; y57i = x5i - x7i;
+              y68r = x6r - x8r; y68i = x6i - x8i;
+              /*  - along 3rd dim: */
+              y15r = x1r - x5r; y15i = x1i - x5i;
+              y26r = x2r - x6r; y26i = x2i - x6i;
+              y37r = x3r - x7r; y37i = x3i - x7i;
+              y48r = x4r - x8r; y48i = x4i - x8i;
+              /* Compute the cost. */
+              r = (SQ(y12r) + SQ(y34r) + SQ(y56r) + SQ(y78r) +
+                   SQ(y13r) + SQ(y24r) + SQ(y57r) + SQ(y68r) +
+                   SQ(y15r) + SQ(y26r) + SQ(y37r) + SQ(y48r) +
+                   SQ(y12i) + SQ(y34i) + SQ(y56i) + SQ(y78i) +
+                   SQ(y13i) + SQ(y24i) + SQ(y57i) + SQ(y68i) +
+                   SQ(y15i) + SQ(y26i) + SQ(y37i) + SQ(y48i))*q;
+              fx += sqrt(r + s);
+            }
+          }
+        }
+      }
+    } else /* not same weights along all directions */ {
+      double p1, q1 = w1/4.0;
+      double p2, q2 = w2/4.0;
+      double p3, q3 = w3/4.0;
+      if (compute_gradient) {
+        for (i3 = 1; i3 < n3; ++i3) {
+          for (i2 = 1; i2 < n2; ++i2) {
+            j8 = OFF3(0, i2,   i3);
+            j6 = OFF3(0, i2-1, i3);
+            j4 = OFF3(0, i2,   i3-1);
+            j2 = OFF3(0, i2-1, i3-1);
+            x2r = xr[j2]; x2i = xi[j2]; 
+            x4r = xr[j4]; x4i = xi[j4];
+            x6r = xr[j6]; x6i = xi[j6];
+            x8r = xr[j8]; x8i = xi[j8];
+            for (i1 = 1; i1 < n1; ++i1) {
+              /* Peak the values at the 8 corners of the cube. */
+              j1 = j2++; x1r = x2r; x2r = xr[j2]; x1i = x2i; x2i = xi[j2];
+              j3 = j4++; x3r = x4r; x4r = xr[j4]; x3i = x4i; x4i = xi[j4];
+              j5 = j6++; x5r = x6r; x6r = xr[j6]; x5i = x6i; x6i = xi[j6];
+              j7 = j8++; x7r = x8r; x8r = xr[j8]; x7i = x8i; x8i = xi[j8];
+              /* Compute the differences along all the 12 edges of the cube: */
+              /*  - along 1st dim: */
+              y12r = x1r - x2r; y12i = x1i - x2i;
+              y34r = x3r - x4r; y34i = x3i - x4i;
+              y56r = x5r - x6r; y56i = x5i - x6i;
+              y78r = x7r - x8r; y78i = x7i - x8i;
+              /*  - along 2nd dim: */
+              y13r = x1r - x3r; y13i = x1i - x3i;
+              y24r = x2r - x4r; y24i = x2i - x4i;
+              y57r = x5r - x7r; y57i = x5i - x7i;
+              y68r = x6r - x8r; y68i = x6i - x8i;
+              /*  - along 3rd dim: */
+              y15r = x1r - x5r; y15i = x1i - x5i;
+              y26r = x2r - x6r; y26i = x2i - x6i;
+              y37r = x3r - x7r; y37i = x3i - x7i;
+              y48r = x4r - x8r; y48i = x4i - x8i;
+              /* Compute the cost and integrate its gradient. */
+              r = ((SQ(y12r) + SQ(y34r) + SQ(y56r) + SQ(y78r))*q1 +
+                   (SQ(y13r) + SQ(y24r) + SQ(y57r) + SQ(y68r))*q2 +
+                   (SQ(y15r) + SQ(y26r) + SQ(y37r) + SQ(y48r))*q3 +
+                   (SQ(y12i) + SQ(y34i) + SQ(y56i) + SQ(y78i))*q1 +
+                   (SQ(y13i) + SQ(y24i) + SQ(y57i) + SQ(y68i))*q2 +
+                   (SQ(y15i) + SQ(y26i) + SQ(y37i) + SQ(y48i))*q3);
+              r = sqrt(r + s);
+              fx += r;
+              r = 1.0/r;
+              p1 = r*q1;
+              p2 = r*q2;
+              p3 = r*q3;
+              y12r *= p1; y12i *= p1;
+              y34r *= p1; y34i *= p1;
+              y56r *= p1; y56i *= p1;
+              y78r *= p1; y78i *= p1;
+              y13r *= p2; y13i *= p2;
+              y24r *= p2; y24i *= p2;
+              y57r *= p2; y57i *= p2;
+              y68r *= p2; y68i *= p2;
+              y15r *= p3; y15i *= p3;
+              y26r *= p3; y26i *= p3;
+              y37r *= p3; y37i *= p3;
+              y48r *= p3; y48i *= p3;
+              gxr[j1] += y12r + y13r + y15r;
+              gxr[j2] -= y12r - y24r - y26r;
+              gxr[j3] += y34r - y13r + y37r;
+              gxr[j4] -= y34r + y24r - y48r;
+              gxr[j5] += y56r + y57r - y15r;
+              gxr[j6] -= y56r - y68r + y26r;
+              gxr[j7] += y78r - y57r - y37r;
+              gxr[j8] -= y78r + y68r + y48r;
+              gxi[j1] += y12i + y13i + y15i;
+              gxi[j2] -= y12i - y24i - y26i;
+              gxi[j3] += y34i - y13i + y37i;
+              gxi[j4] -= y34i + y24i - y48i;
+              gxi[j5] += y56i + y57i - y15i;
+              gxi[j6] -= y56i - y68i + y26i;
+              gxi[j7] += y78i - y57i - y37i;
+              gxi[j8] -= y78i + y68i + y48i;
+            }
+          }
+        }
+      } else /* do not compute gradients */ {
+        for (i3 = 1; i3 < n3; ++i3) {
+          for (i2 = 1; i2 < n2; ++i2) {
+            j8 = OFF3(0, i2,   i3);
+            j6 = OFF3(0, i2-1, i3);
+            j4 = OFF3(0, i2,   i3-1);
+            j2 = OFF3(0, i2-1, i3-1);
+            x2r = xr[j2]; x2i = xi[j2]; 
+            x4r = xr[j4]; x4i = xi[j4];
+            x6r = xr[j6]; x6i = xi[j6];
+            x8r = xr[j8]; x8i = xi[j8];
+            for (i1 = 1; i1 < n1; ++i1) {
+              /* Peak the values at the 8 corners of the cube. */
+              j1 = j2++; x1r = x2r; x2r = xr[j2]; x1i = x2i; x2i = xi[j2];
+              j3 = j4++; x3r = x4r; x4r = xr[j4]; x3i = x4i; x4i = xi[j4];
+              j5 = j6++; x5r = x6r; x6r = xr[j6]; x5i = x6i; x6i = xi[j6];
+              j7 = j8++; x7r = x8r; x8r = xr[j8]; x7i = x8i; x8i = xi[j8];
+              /* Compute the differences along all the 12 edges of the cube: */
+              /*  - along 1st dim: */
+              y12r = x1r - x2r; y12i = x1i - x2i;
+              y34r = x3r - x4r; y34i = x3i - x4i;
+              y56r = x5r - x6r; y56i = x5i - x6i;
+              y78r = x7r - x8r; y78i = x7i - x8i;
+              /*  - along 2nd dim: */
+              y13r = x1r - x3r; y13i = x1i - x3i;
+              y24r = x2r - x4r; y24i = x2i - x4i;
+              y57r = x5r - x7r; y57i = x5i - x7i;
+              y68r = x6r - x8r; y68i = x6i - x8i;
+              /*  - along 3rd dim: */
+              y15r = x1r - x5r; y15i = x1i - x5i;
+              y26r = x2r - x6r; y26i = x2i - x6i;
+              y37r = x3r - x7r; y37i = x3i - x7i;
+              y48r = x4r - x8r; y48i = x4i - x8i;
+              /* Compute the cost and integrate its gradient. */
+              r = ((SQ(y12r) + SQ(y34r) + SQ(y56r) + SQ(y78r))*q1 +
+                   (SQ(y13r) + SQ(y24r) + SQ(y57r) + SQ(y68r))*q2 +
+                   (SQ(y15r) + SQ(y26r) + SQ(y37r) + SQ(y48r))*q3 +
+                   (SQ(y12i) + SQ(y34i) + SQ(y56i) + SQ(y78i))*q1 +
+                   (SQ(y13i) + SQ(y24i) + SQ(y57i) + SQ(y68i))*q2 +
+                   (SQ(y15i) + SQ(y26i) + SQ(y37i) + SQ(y48i))*q3);
               fx += sqrt(r + s);
             }
           }

--- a/totvar.c
+++ b/totvar.c
@@ -569,8 +569,10 @@ double rgl_tv2d_complex(const double xr[], const double xi[],
   fx = 0.0;
   s = eps*eps;
 
-#define  X(a1,a2)   x[OFF2(a1,a2)]
-#define GX(a1,a2)  gx[OFF2(a1,a2)]
+#define  XR(a1,a2)   xr[OFF2(a1,a2)]
+#define GXR(a1,a2)  gxr[OFF2(a1,a2)]
+#define  XI(a1,a2)   xi[OFF2(a1,a2)]
+#define GXI(a1,a2)  gxi[OFF2(a1,a2)]
 
   if (METHOD(flags, RGL_TOTVAR_FORWARD)) {
     /*
@@ -583,12 +585,12 @@ double rgl_tv2d_complex(const double xr[], const double xi[],
     if (compute_gradient) {
       if (w1 == w2) /* same weights along all directions */ {
         for (i2 = 1; i2 < n2; ++i2) {
-          x2r = xr(0, i2-1);
-          x2i = xi(0, i2-1);
+          x2r = XR(0, i2-1);
+          x2i = XI(0, i2-1);
           for (i1 = 1; i1 < n1; ++i1) {
             x1r = x2r;           x1i = x2i;
-            x2r = xr(i1, i2-1);  x2i = xi(i1, i2-1);
-            x3r = xr(i1-1, i2);  x3i = xi(i1-1, i2);
+            x2r = XR(i1, i2-1);  x2i = XI(i1, i2-1);
+            x3r = XR(i1-1, i2);  x3i = XI(i1-1, i2);
             y12r = x1r - x2r;    y12i = x1i - x2i;
             y13r = x1r - x3r;    y13i = x1i - x3i;
             r = (SQ(y12r) + SQ(y13r) + SQ(y12i) + SQ(y13i))*w1;
@@ -599,22 +601,22 @@ double rgl_tv2d_complex(const double xr[], const double xi[],
             y13r *= p;
             y12i *= p;
             y13i *= p;
-            gxr(i1 - 1, i2 - 1) += y12r + y13r; /* deriv. wrt X1 */
-            gxr(i1    , i2 - 1) -= y12r;       /* deriv. wrt X2 */
-            gxr(i1 - 1, i2    ) -= y13r;       /* deriv. wrt X3 */
-            gxi(i1 - 1, i2 - 1) += y12i + y13i; /* deriv. wrt X1 */
-            gxi(i1    , i2 - 1) -= y12i;       /* deriv. wrt X2 */
-            gxi(i1 - 1, i2    ) -= y13i;       /* deriv. wrt X3 */
+            GXR(i1 - 1, i2 - 1) += y12r + y13r; /* deriv. wrt X1 */
+            GXR(i1    , i2 - 1) -= y12r;       /* deriv. wrt X2 */
+            GXR(i1 - 1, i2    ) -= y13r;       /* deriv. wrt X3 */
+            GXI(i1 - 1, i2 - 1) += y12i + y13i; /* deriv. wrt X1 */
+            GXI(i1    , i2 - 1) -= y12i;       /* deriv. wrt X2 */
+            GXI(i1 - 1, i2    ) -= y13i;       /* deriv. wrt X3 */
           }
         }
       } else /* not same weights along all directions */ {
         for (i2 = 1; i2 < n2; ++i2) {
-          x2r = xr(0, i2-1);
-          x2i = xi(0, i2-1);
+          x2r = XR(0, i2-1);
+          x2i = XI(0, i2-1);
           for (i1 = 1; i1 < n1; ++i1) {
             x1r = x2r;           x1i = x2i;
-            x2r = xr(i1, i2-1);  x2i = xi(i1, i2-1);
-            x3r = xr(i1-1, i2);  x3i = xi(i1-1, i2);
+            x2r = XR(i1, i2-1);  x2i = XI(i1, i2-1);
+            x3r = XR(i1-1, i2);  x3i = XI(i1-1, i2);
             y12r = x1r - x2r;    y12i = x1i - x2i;
             y13r = x1r - x3r;    y13i = x1i - x3i;
             r = SQ(y12r)*w1 + SQ(y13r)*w2 + SQ(y12i)*w1 + SQ(y13i)*w2;
@@ -625,24 +627,24 @@ double rgl_tv2d_complex(const double xr[], const double xi[],
             y13r *= p*w2;
             y12i *= p*w1;
             y13i *= p*w2;
-            gxr(i1 - 1, i2 - 1) += y12r + y13r; /* deriv. wrt X1 */
-            gxr(i1    , i2 - 1) -= y12r;       /* deriv. wrt X2 */
-            gxr(i1 - 1, i2    ) -= y13r;       /* deriv. wrt X3 */
-            gxi(i1 - 1, i2 - 1) += y12i + y13i; /* deriv. wrt X1 */
-            gxi(i1    , i2 - 1) -= y12i;       /* deriv. wrt X2 */
-            gxi(i1 - 1, i2    ) -= y13i;       /* deriv. wrt X3 */
+            GXR(i1 - 1, i2 - 1) += y12r + y13r; /* deriv. wrt X1 */
+            GXR(i1    , i2 - 1) -= y12r;       /* deriv. wrt X2 */
+            GXR(i1 - 1, i2    ) -= y13r;       /* deriv. wrt X3 */
+            GXI(i1 - 1, i2 - 1) += y12i + y13i; /* deriv. wrt X1 */
+            GXI(i1    , i2 - 1) -= y12i;       /* deriv. wrt X2 */
+            GXI(i1 - 1, i2    ) -= y13i;       /* deriv. wrt X3 */
           }
         }
       }
     } else /* do not compute gradients */ {
       if (w1 == w2) /* same weights along all directions */ {
         for (i2 = 1; i2 < n2; ++i2) {
-          x2r = xr(0, i2-1);
-          x2i = xi(0, i2-1);
+          x2r = XR(0, i2-1);
+          x2i = XI(0, i2-1);
           for (i1 = 1; i1 < n1; ++i1) {
             x1r = x2r;           x1i = x2i;
-            x2r = xr(i1, i2-1);  x2i = xi(i1, i2-1);
-            x3r = xr(i1-1, i2);  x3i = xi(i1-1, i2);
+            x2r = XR(i1, i2-1);  x2i = XI(i1, i2-1);
+            x3r = XR(i1-1, i2);  x3i = XI(i1-1, i2);
             y12r = x1r - x2r;    y12i = x1i - x2i;
             y13r = x1r - x3r;    y13i = x1i - x3i;
             r = (SQ(y12r) + SQ(y13r) + SQ(y12i) + SQ(y13i))*w1;
@@ -651,12 +653,12 @@ double rgl_tv2d_complex(const double xr[], const double xi[],
         }
       } else /* not same weights along all directions */ {
         for (i2 = 1; i2 < n2; ++i2) {
-          x2r = xr(0, i2-1);
-          x2i = xi(0, i2-1);
+          x2r = XR(0, i2-1);
+          x2i = XI(0, i2-1);
           for (i1 = 1; i1 < n1; ++i1) {
             x1r = x2r;           x1i = x2i;
-            x2r = xr(i1, i2-1);  x2i = xi(i1, i2-1);
-            x3r = xr(i1-1, i2);  x3i = xi(i1-1, i2);
+            x2r = XR(i1, i2-1);  x2i = XI(i1, i2-1);
+            x3r = XR(i1-1, i2);  x3i = XI(i1-1, i2);
             y12r = x1r - x2r;    y12i = x1i - x2i;
             y13r = x1r - x3r;    y13i = x1i - x3i;
             r = SQ(y12r)*w1 + SQ(y13r)*w2 + SQ(y12i)*w1 + SQ(y13i)*w2;

--- a/totvar.h
+++ b/totvar.h
@@ -29,7 +29,7 @@
  * computer knowledge. Users are therefore encouraged to load and test the
  * software's suitability as regards their requirements in conditions enabling
  * the security of their systems and/or data to be ensured and, more
- * generally, to use and operate it in the same conditions as regards
+ * generally, to use and operate it in the conditions as regards
  * security.
  *
  * The fact that you are presently reading this means that you have had
@@ -64,10 +64,22 @@ extern double rgl_tv2d(const double x[],
                        const double eps, double gx[],
                        unsigned int flags);
 
+extern double rgl_tv2d_complex(const double xr[], const double xi[],
+                       const long n1, const long n2,
+                       const double w1, const double w2,
+                       const double eps, double gxr[], double gxi[],
+                       unsigned int flags);
+
 extern double rgl_tv3d(const double x[],
                        const long n1, const long n2, const long n3,
                        const double w1, const double w2, const double w3,
                        const double eps, double gx[],
+                       unsigned int flags);
+
+extern double rgl_tv3d_complex(const double xr[], const double xi[],
+                       const long n1, const long n2, const long n3,
+                       const double w1, const double w2, const double w3,
+                       const double eps, double gxr[], double gxi[],
                        unsigned int flags);
 
 extern double rgl_tv4d(const double x[],


### PR DESCRIPTION
- Ajout au code C des fonctions rgl_tv2d_complex et rgl_tv3d_complex qui permettent de calculer TV 2D et 3D sur des images à valeurs complexes en considérant partie réelle et imaginaire en chaque pixel comme un vecteur à 2 composantes. On réalise alors un TV "groupé" sur ces composantes (type group-lasso).

- Implémentation des MEX functions pour chaque TV (2D/3D, réel/complexe) pour l'interfaçage avec Matlab. Les fonctions ont été rapidement testées et semblent bien fonctionner.